### PR TITLE
Use fuzzy comparison for another Flickable StopAtBounds case.

### DIFF
--- a/src/quick/items/qquickflickable.cpp
+++ b/src/quick/items/qquickflickable.cpp
@@ -1015,11 +1015,11 @@ void QQuickFlickablePrivate::handleMouseMoveEvent(QMouseEvent *event)
             const qreal minY = vData.dragMinBound + vData.startMargin;
             const qreal maxY = vData.dragMaxBound - vData.endMargin;
             if (boundsBehavior == QQuickFlickable::StopAtBounds) {
-                if (newY <= maxY) {
+                if (fuzzyLessThanOrEqualTo(newY, maxY)) {
                     newY = maxY;
                     rejectY = vData.pressPos == maxY && vData.move.value() == maxY && dy < 0;
                 }
-                if (newY >= minY) {
+                if (fuzzyLessThanOrEqualTo(minY, newY)) {
                     newY = minY;
                     rejectY = vData.pressPos == minY && vData.move.value() == minY && dy > 0;
                 }
@@ -1049,11 +1049,11 @@ void QQuickFlickablePrivate::handleMouseMoveEvent(QMouseEvent *event)
             const qreal minX = hData.dragMinBound + hData.startMargin;
             const qreal maxX = hData.dragMaxBound - hData.endMargin;
             if (boundsBehavior == QQuickFlickable::StopAtBounds) {
-                if (newX <= maxX) {
+                if (fuzzyLessThanOrEqualTo(newX, maxX)) {
                     newX = maxX;
                     rejectX = hData.pressPos == maxX && hData.move.value() == maxX && dx < 0;
                 }
-                if (newX >= minX) {
+                if (fuzzyLessThanOrEqualTo(minX, newX)) {
                     newX = minX;
                     rejectX = hData.pressPos == minX && hData.move.value() == minX && dx > 0;
                 }


### PR DESCRIPTION
Be consistent with 268f4615dcf19aad3603833af83ba28eca886aa5, and use
fuzzyLessThanOrEqualTo when checking whether we are at or past the bounds
when dragging. This prevents a condition where:
1. A Flickable with StopAtBounds is at one of the bounds.
2. A quick flick will sometimes (rarely) cause the Flickable to flick
   past the bounds.

Change-Id: I4165fa133f556fb9d47cc691d11b2ecb77746b33
Reviewed-by: Martin Jones martin.jones@jollamobile.com
