### PR TITLE
QQuickTimeLine: add missing time checks

### DIFF
--- a/src/quick/util/qquicktimeline.cpp
+++ b/src/quick/util/qquicktimeline.cpp
@@ -396,6 +396,7 @@ int QQuickTimeLine::accel(QQuickTimeLineValue &timeLineValue, qreal velocity, qr
         acceleration = acceleration * -1.0f;
 
     int time = static_cast<int>(-1000 * velocity / acceleration);
+    if (time <= 0) return -1;
 
     QQuickTimeLinePrivate::Op op(QQuickTimeLinePrivate::Op::Accel, time, velocity, acceleration, d->order++);
     d->add(timeLineValue, op);
@@ -428,6 +429,7 @@ int QQuickTimeLine::accel(QQuickTimeLineValue &timeLineValue, qreal velocity, qr
         acceleration = acceleration * -1.0f;
 
     int time = static_cast<int>(-1000 * velocity / acceleration);
+    if (time <= 0) return -1;
 
     QQuickTimeLinePrivate::Op op(QQuickTimeLinePrivate::Op::Accel, time, velocity, acceleration, d->order++);
     d->add(timeLineValue, op);
@@ -450,6 +452,7 @@ int QQuickTimeLine::accelDistance(QQuickTimeLineValue &timeLineValue, qreal velo
     Q_ASSERT((distance >= 0.0f) == (velocity >= 0.0f));
 
     int time = static_cast<int>(1000 * (2.0f * distance) / velocity);
+    if (time <= 0) return -1;
 
     QQuickTimeLinePrivate::Op op(QQuickTimeLinePrivate::Op::AccelDistance, time, velocity, distance, d->order++);
     d->add(timeLineValue, op);

--- a/tests/auto/quick/qquicktimeline/qquicktimeline.pro
+++ b/tests/auto/quick/qquicktimeline/qquicktimeline.pro
@@ -1,0 +1,9 @@
+CONFIG += testcase
+CONFIG += parallel_test
+TARGET = tst_qquicktimeline
+macx:CONFIG -= app_bundle
+
+SOURCES += tst_qquicktimeline.cpp
+QT += core-private gui-private qml quick qml-private quick-private testlib
+
+DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0

--- a/tests/auto/quick/qquicktimeline/tst_qquicktimeline.cpp
+++ b/tests/auto/quick/qquicktimeline/tst_qquicktimeline.cpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Digia Plc and/or its subsidiary(-ies).
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the test suite of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#include <qtest.h>
+#include <private/qquicktimeline_p_p.h>
+#include <limits>
+
+class tst_QQuickTimeLine : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void overflow();
+};
+
+void tst_QQuickTimeLine::overflow()
+{
+    QQuickTimeLine timeline;
+    QQuickTimeLineValue value;
+
+    // overflow -> negative time -> assertion failure (QTBUG-35046)
+    QCOMPARE(timeline.accel(value, std::numeric_limits<qreal>::max(), 0.0001f), -1);
+    QCOMPARE(timeline.accel(value, std::numeric_limits<qreal>::max(), 0.0001f, 0.0001f), -1);
+    QCOMPARE(timeline.accelDistance(value, 0.0001f, std::numeric_limits<qreal>::max()), -1);
+}
+
+QTEST_MAIN(tst_QQuickTimeLine)
+
+#include "tst_qquicktimeline.moc"

--- a/tests/auto/quick/quick.pro
+++ b/tests/auto/quick/quick.pro
@@ -26,6 +26,7 @@ PRIVATETESTS += \
     qquickstyledtext \
     qquickstates \
     qquicksystempalette \
+    qquicktimeline \
     qquickxmllistmodel
 
 # This test requires the xmlpatterns module


### PR DESCRIPTION
The same check is done in QQuickTimeLine::pause(), move() and moveBy(),
where the time is passed as an argument. QQuickTimeLine::accel() and
accelDistance() calculate the time based on velocity and acceleration
or distance. With tiny values this calculation can result to a negative
time due to integer overflow.

Task-number: QTBUG-35046
Change-Id: I000e73d3f787375946e8f87a5d24153ae919bc8d
Reviewed-by: Michael Brasser michael.brasser@live.com
