### PR TITLE
[qtdeclarative] Fix memory corruption bug

### DIFF
--- a/src/qml/qml/qqmlengine.cpp
+++ b/src/qml/qml/qqmlengine.cpp
@@ -1586,17 +1586,6 @@ void QQmlData::destroyed(QObject *object)
         binding = next;
     }
 
-    if (compiledData) {
-        compiledData->release();
-        compiledData = 0;
-    }
-
-    if (deferredData) {
-        deferredData->compiledData->release();
-        delete deferredData;
-        deferredData = 0;
-    }
-
     QQmlAbstractBoundSignal *signalHandler = signalHandlers;
     while (signalHandler) {
         if (signalHandler->isEvaluating()) {
@@ -1651,6 +1640,17 @@ void QQmlData::destroyed(QObject *object)
     }
 
     disconnectNotifiers();
+
+    if (compiledData) {
+        compiledData->release();
+        compiledData = 0;
+    }
+
+    if (deferredData) {
+        deferredData->compiledData->release();
+        delete deferredData;
+        deferredData = 0;
+    }
 
     if (extendedData)
         delete extendedData;


### PR DESCRIPTION
This is the same fix that was applied to mer-packages/qtdeclarative
https://github.com/mer-packages/qtdeclarative/commit/3cfbd9d3176cbbc95bdbe3712f4accdc1485ed55
