### PR TITLE
[qtdeclarative] Fix crash on shutdown

### DIFF
--- a/src/quick/scenegraph/qsgrenderloop_p.h
+++ b/src/quick/scenegraph/qsgrenderloop_p.h
@@ -44,6 +44,7 @@
 
 #include <QtGui/QImage>
 #include <private/qtquickglobal_p.h>
+#include <QtCore/QSet>
 
 QT_BEGIN_NAMESPACE
 
@@ -78,6 +79,10 @@ public:
 
     virtual void releaseResources(QQuickWindow *window) = 0;
 
+    void addWindow(QQuickWindow *win) { m_windows.insert(win); }
+    void removeWindow(QQuickWindow *win) { m_windows.remove(win); }
+    QSet<QQuickWindow *> windows() const { return m_windows; }
+
     // ### make this less of a singleton
     static QSGRenderLoop *instance();
     static void setInstance(QSGRenderLoop *instance);
@@ -88,6 +93,14 @@ public:
 
 Q_SIGNALS:
     void timeToIncubate();
+
+public Q_SLOTS:
+    void cleanup();
+
+private:
+    static QSGRenderLoop *s_instance;
+
+    QSet<QQuickWindow *> m_windows;
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
commit 52b20d12a3593e776433c4f3ec1c6230755f1445
Author: Gunnar Sletta gunnar.sletta@jollamobile.com
Date:   Fri Mar 14 15:15:26 2014 +0100

```
Fix potential crash during shutdown for QQuickWindows

The cleanup() function would deregister the render loop from all
windows the render loop had seen, but the render loop doesn't see
windows until the window gets a showEvent and for some implementations
it was removed as a result of hideEvent. So add explicit tracking to
QSGRenderLoop which is managed by QQuickWindow's constructor and
destructor. With this, we no longer need the lists from the
subclasses, so these functions are removed again.

Change-Id: I05e5507ad57e23c80bacd99752654cc7d0890dc1
Reviewed-by: Paul Olav Tvete <paul.tvete@digia.com>

Conflicts:
    src/quick/items/qquickwindow.cpp
```

commit 60bec30befb6468db79ab2acac6fcc7a389acca8
Author: Gunnar Sletta gunnar.sletta@jollamobile.com
Date:   Wed Mar 5 15:38:02 2014 +0100

```
Make sure QSGRenderLoop is cleaned up cleanly.

e13547c595913c58e6bd6a5ed80fdc729fae7d47 used a global static to clean
up QSGRenderLoop which is triggered very late, potentially after
SG backend API plugins have been unloaded. This results in crashes
when used in combination with scenegraph-playgrounds's customcontext.

Partially revert the change and instead clean up at the time of
QApp::aboutToQuit and make sure we also disconnect cleanly from
all QQuickWindows.

This change also ensures that QSGRenderLoop::windowDestroyed() gets
called for all QQuickWindows registered with the render loop. This
ensures that rendering stops and that scene graph nodes and resources
will be cleaned up regardless of whether the application has
remembered to delete the window or not. This is a good thing as it
makes the scene graph shutdown a bit cleaner.

Change-Id: I9cb9093979f8eac05542f118a6ff9cfe5c84f745
Reviewed-by: Paul Olav Tvete <paul.tvete@digia.com>

Conflicts:
    src/quick/items/qquickwindow.cpp
    src/quick/scenegraph/qsgrenderloop.cpp
    src/quick/scenegraph/qsgrenderloop_p.h
```

Change-Id: I14b60be55ed5fde72f38f48a79edc0b49f853a0c
