### PR TITLE
[qtdeclarative] Fix marking of prototype objects in internal class pool

### DIFF
--- a/src/qml/jsruntime/qv4engine_p.h
+++ b/src/qml/jsruntime/qv4engine_p.h
@@ -106,6 +106,7 @@ struct SequencePrototype;
 struct EvalFunction;
 struct IdentifierTable;
 struct InternalClass;
+struct InternalClassPool;
 class MultiplyWrappedQObjectMap;
 class RegExp;
 class RegExpCache;
@@ -191,7 +192,7 @@ public:
     SafeValue uRIErrorCtor;
     SafeValue sequencePrototype;
 
-    QQmlJS::MemoryPool classPool;
+    InternalClassPool *classPool;
     InternalClass *emptyClass;
     InternalClass *executionContextClass;
     InternalClass *stringClass;

--- a/src/qml/jsruntime/qv4internalclass.cpp
+++ b/src/qml/jsruntime/qv4internalclass.cpp
@@ -129,7 +129,7 @@ uint PropertyHash::lookup(const Identifier *identifier) const
 InternalClass::InternalClass(ExecutionEngine *engine)
     : engine(engine)
     , prototype(0)
-    , vtable(&Managed::static_vtbl)
+    , vtable(&QV4::Managed::static_vtbl)
     , m_sealed(0)
     , m_frozen(0)
     , size(0)
@@ -138,7 +138,8 @@ InternalClass::InternalClass(ExecutionEngine *engine)
 
 
 InternalClass::InternalClass(const QV4::InternalClass &other)
-    : engine(other.engine)
+    : QQmlJS::Managed()
+    , engine(other.engine)
     , prototype(other.prototype)
     , vtable(other.vtable)
     , propertyTable(other.propertyTable)
@@ -386,17 +387,24 @@ void InternalClass::destroy()
     transitions.clear();
 }
 
-void InternalClass::markObjects()
+void InternalClassPool::markObjects(ExecutionEngine *engine)
 {
-    // all prototype changes are done on the empty class
-    Q_ASSERT(!prototype || this != engine->emptyClass);
+    struct Visitor
+    {
+        ExecutionEngine *engine;
+        void operator()(InternalClass *klass)
+        {
+            // all prototype changes are done on the empty class
+            Q_ASSERT(!klass->prototype || klass != engine->emptyClass);
 
-    if (prototype)
-        prototype->mark(engine);
+            if (klass->prototype)
+                klass->prototype->mark(engine);
+        }
+    };
 
-    for (QHash<Transition, InternalClass *>::ConstIterator it = transitions.begin(), end = transitions.end();
-         it != end; ++it)
-        it.value()->markObjects();
+    Visitor v;
+    v.engine = engine;
+    visitManagedPool<InternalClass>(v);
 }
 
 QT_END_NAMESPACE

--- a/src/qml/jsruntime/qv4internalclass_p.h
+++ b/src/qml/jsruntime/qv4internalclass_p.h
@@ -44,6 +44,7 @@
 #include <QHash>
 #include <QVector>
 #include "qv4global_p.h"
+#include <private/qqmljsmemorypool_p.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -213,7 +214,7 @@ struct InternalClassTransition
 };
 uint qHash(const QV4::InternalClassTransition &t, uint = 0);
 
-struct InternalClass {
+struct InternalClass : public QQmlJS::Managed {
     ExecutionEngine *engine;
     Object *prototype;
     const ManagedVTable *vtable;
@@ -244,12 +245,16 @@ struct InternalClass {
     InternalClass *frozen();
 
     void destroy();
-    void markObjects();
 
 private:
     friend struct ExecutionEngine;
     InternalClass(ExecutionEngine *engine);
     InternalClass(const InternalClass &other);
+};
+
+struct InternalClassPool : public QQmlJS::MemoryPool
+{
+    void markObjects(ExecutionEngine *engine);
 };
 
 }

--- a/src/qml/parser/qqmljsmemorypool_p.h
+++ b/src/qml/parser/qqmljsmemorypool_p.h
@@ -65,6 +65,8 @@ QT_QML_BEGIN_NAMESPACE
 
 namespace QQmlJS {
 
+class Managed;
+
 class QML_PARSER_EXPORT MemoryPool : public QSharedData
 {
     MemoryPool(const MemoryPool &other);
@@ -106,6 +108,28 @@ public:
     {
         _blockCount = -1;
         _ptr = _end = 0;
+    }
+
+    template <typename PoolContentType, typename Visitor>
+    void visitManagedPool(Visitor &visitor)
+    {
+        for (int i = 0; i <= _blockCount; ++i) {
+            char *p = _blocks[i];
+            char *end = p + BLOCK_SIZE;
+            if (i == _blockCount) {
+                Q_ASSERT(_ptr <= end);
+                end = _ptr;
+            }
+
+            Q_ASSERT(p <= end);
+
+            const qptrdiff increment = (sizeof(PoolContentType) + 7) & ~7;
+
+            while (p + increment <= end) {
+                visitor(reinterpret_cast<PoolContentType*>(p));
+                p += increment;
+            }
+        }
     }
 
 private:


### PR DESCRIPTION
As per reported bug, we have to protect ourselves against potential loops
and can mark the internal classes much simpler by just walking through
the memory pool they were allocated in.

Task-number: QTBUG-38299
Change-Id: I3ae96e8082e76d06f4321c5aa6d2e9645d2830a0
