### PR TITLE
[qtdeclarative] Make sure Behavior animations start when triggered from touch events.

### DIFF
--- a/src/quick/scenegraph/qsgthreadedrenderloop_p.h
+++ b/src/quick/scenegraph/qsgthreadedrenderloop_p.h
@@ -95,6 +95,7 @@ private:
 
     void releaseResources(QQuickWindow *window, bool inDestructor);
     bool checkAndResetForceUpdate(QQuickWindow *window);
+    Window *windowForTimer(int timerId) const;
 
     bool anyoneShowing() const;
     void initialize();


### PR DESCRIPTION
We need to process events after flushing the touch touch events so
metacalls (which are used inside the animation system to start
animations) get triggered.

This is an ammendment to to Change-Id:
Ia0169bc4a3f0da67709b91ca65c326934b55d372

Change-Id: I8a986c6d28ab3b829d4c711923c23e1d6088b7ac
