### PR TITLE
Be conservative with atlas allocation for Cover windows.

### DIFF
--- a/src/quick/scenegraph/util/qsgatlastexture.cpp
+++ b/src/quick/scenegraph/util/qsgatlastexture.cpp
@@ -48,6 +48,7 @@
 #include <QtGui/QGuiApplication>
 #include <QtGui/QScreen>
 #include <QtGui/QSurface>
+#include <QtGui/QWindow>
 #include <QtGui/qpa/qplatformnativeinterface.h>
 
 #include <private/qsgtexture_p.h>
@@ -103,6 +104,15 @@ Manager::Manager()
 
     int w = qMin(max, qsg_envInt("QSG_ATLAS_WIDTH", qMax(512, qsg_powerOfTwo(surfaceSize.width()))));
     int h = qMin(max, qsg_envInt("QSG_ATLAS_HEIGHT", qMax(512, qsg_powerOfTwo(surfaceSize.height()))));
+
+    if (surface->surfaceClass() == QSurface::Window) {
+        QWindow *window = static_cast<QWindow *>(surface);
+        // Coverwindows, optimize for memory rather than speed
+        if ((window->type() & Qt::CoverWindow) == Qt::CoverWindow) {
+            w /= 2;
+            h /= 2;
+        }
+    }
 
     m_atlas_size_limit = qsg_envInt("QSG_ATLAS_SIZE_LIMIT", qMax(w, h) / 2);
     m_atlas_size = QSize(w, h);


### PR DESCRIPTION
These are usually small and require a very small amount of textures.

Change-Id: I51a1d2965c37ac39c1f1f70d9bb6d7baf41e0562
Reviewed-by: Giulio Camuffo giulio.camuffo@jollamobile.com
Reviewed-by: Robin Burchell <robin+qt@viroteck.net>
Reviewed-by: Laszlo Agocs laszlo.agocs@digia.com
