### PR TITLE
Fix crash on QQmlEngine destruction.

### DIFF
--- a/src/qml/qml/qqmlengine.cpp
+++ b/src/qml/qml/qqmlengine.cpp
@@ -559,7 +559,7 @@ QQmlEnginePrivate::QQmlEnginePrivate(QQmlEngine *e)
   workerScriptEngine(0), activeVME(0),
   activeObjectCreator(0),
   networkAccessManager(0), networkAccessManagerFactory(0), urlInterceptor(0),
-  scarceResourcesRefCount(0), importDatabase(e), typeLoader(e), uniqueId(1),
+  scarceResourcesRefCount(0), typeLoader(e), importDatabase(e), uniqueId(1),
   incubatorCount(0), incubationController(0), mutex(QMutex::Recursive)
 {
     useNewCompiler = qmlUseNewCompiler();

--- a/src/qml/qml/qqmlengine_p.h
+++ b/src/qml/qml/qqmlengine_p.h
@@ -186,8 +186,9 @@ public:
     void referenceScarceResources();
     void dereferenceScarceResources();
 
-    QQmlImportDatabase importDatabase;
     QQmlTypeLoader typeLoader;
+    QQmlImportDatabase importDatabase;
+
 
     QString offlineStoragePath;
 


### PR DESCRIPTION
QQmlTypeLoader references QQmlImportDatabase in a thread, so change the
declaration order so QQmlTypeLoader is destroyed and its thread stopped
before QQmlImportDatabase is destroyed.

Change-Id: Idfa511cf9625f893c4398f419a74d869169b478d

https://codereview.qt-project.org/88537
