### PR TITLE
Fix crash in Flickable with pressDelay.

### DIFF
--- a/src/quick/items/qquickflickable.cpp
+++ b/src/quick/items/qquickflickable.cpp
@@ -1360,15 +1360,15 @@ void QQuickFlickablePrivate::replayDelayedPress()
         delayedPressTimer.stop();
 
         // If we have the grab, release before delivering the event
-        QQuickWindow *w = q->window();
-        if (w && (w->mouseGrabberItem() == q)) {
-            q->ungrabMouse();
-        }
+        if (QQuickWindow *w = q->window()) {
+            if (w->mouseGrabberItem() == q)
+                q->ungrabMouse();
 
-        // Use the event handler that will take care of finding the proper item to propagate the event
-        replayingPressEvent = true;
-        QQuickWindowPrivate::get(w)->deliverMouseEvent(mouseEvent.data());
-        replayingPressEvent = false;
+            // Use the event handler that will take care of finding the proper item to propagate the event
+            replayingPressEvent = true;
+            QQuickWindowPrivate::get(w)->deliverMouseEvent(mouseEvent.data());
+            replayingPressEvent = false;
+        }
     }
 }
 


### PR DESCRIPTION
Looks like this was exposed by the touch event compression change.
