### PR TITLE
[qtdeclarative] Binding Text width to implicitWidth can result in incorr...

### DIFF
--- a/src/quick/items/qquicktext.cpp
+++ b/src/quick/items/qquicktext.cpp
@@ -940,9 +940,10 @@ QRectF QQuickTextPrivate::setupTextLayout(qreal *const baseline)
             maxHeight = q->heightValid() ? q->height() : FLT_MAX;
 
             // If the width of the item has changed and it's possible the result of wrapping,
-            // eliding, or scaling has changed do another layout.
+            // eliding, scaling has changed, or the text is not left aligned do another layout.
             if ((lineWidth < qMin(oldWidth, naturalWidth) || (widthExceeded && lineWidth > oldWidth))
-                    && (singlelineElide || multilineElide || canWrap || horizontalFit)) {
+                    && (singlelineElide || multilineElide || canWrap || horizontalFit
+                        || q->effectiveHAlign() != QQuickText::AlignLeft)) {
                 widthExceeded = false;
                 heightExceeded = false;
                 continue;


### PR DESCRIPTION
...ect layout

If the text is not left aligned and the width changes during layout due
to implictWidth changing, the text needs to be laid out again.

Upstream change: https://codereview.qt-project.org/#/c/89555/
