### PR TITLE
[qtdeclarative] backport positioning bugfix for Item.layer

### DIFF
--- a/src/quick/items/qquickitem.cpp
+++ b/src/quick/items/qquickitem.cpp
@@ -5372,6 +5372,17 @@ void QQuickItemPrivate::setEffectiveEnableRecur(QQuickItem *scope, bool newEffec
     emit q->enabledChanged();
 }
 
+bool QQuickItemPrivate::isTransparentForPositioner() const
+{
+    return extra.isAllocated() && extra.value().transparentForPositioner;
+}
+
+void QQuickItemPrivate::setTransparentForPositioner(bool transparent)
+{
+    extra.value().transparentForPositioner = transparent;
+}
+
+
 QString QQuickItemPrivate::dirtyToString() const
 {
 #define DIRTY_TO_STRING(value) if (dirtyAttributes & value) { \
@@ -7205,6 +7216,7 @@ void QQuickItemLayer::activate()
 {
     Q_ASSERT(!m_effectSource);
     m_effectSource = new QQuickShaderEffectSource();
+    QQuickItemPrivate::get(m_effectSource)->setTransparentForPositioner(true);
 
     QQuickItem *parentItem = m_item->parentItem();
     if (parentItem) {
@@ -7270,6 +7282,7 @@ void QQuickItemLayer::activateEffect()
     }
     m_effect->setVisible(m_item->isVisible());
     m_effect->setProperty(m_name, qVariantFromValue<QObject *>(m_effectSource));
+    QQuickItemPrivate::get(m_effect)->setTransparentForPositioner(true);
     m_effectComponent->completeCreate();
 }
 
@@ -7583,7 +7596,8 @@ QQuickItemPrivate::ExtraData::ExtraData()
   keyHandler(0), layer(0),
   effectRefCount(0), hideRefCount(0),
   opacityNode(0), clipNode(0), rootNode(0),
-  acceptedMouseButtons(0), origin(QQuickItem::Center)
+  acceptedMouseButtons(0), origin(QQuickItem::Center),
+  transparentForPositioner(false)
 {
 }
 

--- a/src/quick/items/qquickitem_p.h
+++ b/src/quick/items/qquickitem_p.h
@@ -369,6 +369,7 @@ public:
         Qt::MouseButtons acceptedMouseButtons;
 
         QQuickItem::TransformOrigin origin:5;
+        uint transparentForPositioner : 1;
 
         // 26 bits padding
     };
@@ -542,6 +543,9 @@ public:
 #ifndef QT_NO_IM
     void deliverInputMethodEvent(QInputMethodEvent *);
 #endif
+
+    bool isTransparentForPositioner() const;
+    void setTransparentForPositioner(bool trans);
 
     bool calcEffectiveVisible() const;
     bool setEffectiveVisibleRecur(bool);

--- a/src/quick/items/qquickpositioners.cpp
+++ b/src/quick/items/qquickpositioners.cpp
@@ -305,6 +305,8 @@ void QQuickBasePositioner::prePositioning()
 
     for (int ii = 0; ii < children.count(); ++ii) {
         QQuickItem *child = children.at(ii);
+        if (QQuickItemPrivate::get(child)->isTransparentForPositioner())
+            continue;
         QQuickItemPrivate *childPrivate = QQuickItemPrivate::get(child);
         PositionedItem posItem(child);
         int wIdx = oldItems.find(posItem);
@@ -1038,7 +1040,7 @@ void QQuickRow::reportConflictingAnchors()
 
     \image gridLayout_example.png
 
-    If an item within a Column is not \l {Item::}{visible}, or if it has a width or
+    If an item within a Grid is not \l {Item::}{visible}, or if it has a width or
     height of 0, the item will not be laid out and it will not be visible within the
     column. Also, since a Grid automatically positions its children, a child
     item within a Grid should not set its \l {Item::x}{x} or \l {Item::y}{y} positions

--- a/tests/auto/qmltest/item/tst_layerInPositioner.qml
+++ b/tests/auto/qmltest/item/tst_layerInPositioner.qml
@@ -1,0 +1,207 @@
+/****************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd, author: <gunnar.sletta@jollamobile.com>
+** Contact: http://www.qt-project.org/legal
+**
+** This file is part of the test suite of the Qt Toolkit.
+**
+** $QT_BEGIN_LICENSE:LGPL$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and Digia.  For licensing terms and
+** conditions see http://qt.digia.com/licensing.  For further information
+** use the contact form at http://qt.digia.com/contact-us.
+**
+** GNU Lesser General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+** In addition, as a special exception, Digia gives you certain additional
+** rights.  These rights are described in the Digia Qt LGPL Exception
+** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+**
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3.0 as published by the Free Software
+** Foundation and appearing in the file LICENSE.GPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU General Public License version 3.0 requirements will be
+** met: http://www.gnu.org/copyleft/gpl.html.
+**
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+import QtQuick 2.4
+import QtTest 1.0
+
+Item {
+    id: root;
+    width: 400
+    height: 400
+
+    TestCase {
+        id: testCase
+        name: "transparentForPositioner"
+        when: windowShown
+        function test_endresult() {
+            var image = grabImage(root);
+
+            // Row of red, green, blue and white box inside blue
+            // At 10,10, spanning 10x10 pixels each
+            verify(image.pixel(10, 10) == Qt.rgba(1, 0, 0, 1));
+            verify(image.pixel(20, 10) == Qt.rgba(0, 1, 0, 1));
+            verify(image.pixel(30, 10) == Qt.rgba(0, 0, 1, 1));
+
+            // Column of red, green, blue and white box inside blue
+            // At 10,30, spanning 10x10 pixels each
+            verify(image.pixel(10, 30) == Qt.rgba(1, 0, 0, 1));
+            verify(image.pixel(10, 40) == Qt.rgba(0, 1, 0, 1));
+            verify(image.pixel(10, 50) == Qt.rgba(0, 0, 1, 1));
+
+            // Flow of red, green, blue and white box inside blue
+            // At 30,30, spanning 10x10 pixels each, wrapping after two boxes
+            verify(image.pixel(30, 30) == Qt.rgba(1, 0, 0, 1));
+            verify(image.pixel(40, 30) == Qt.rgba(0, 1, 0, 1));
+            verify(image.pixel(30, 40) == Qt.rgba(0, 0, 1, 1));
+
+            // Flow of red, green, blue and white box inside blue
+            // At 100,10, spanning 10x10 pixels each, wrapping after two boxes
+            verify(image.pixel(60, 10) == Qt.rgba(1, 0, 0, 1));
+            verify(image.pixel(70, 10) == Qt.rgba(0, 1, 0, 1));
+            verify(image.pixel(60, 20) == Qt.rgba(0, 0, 1, 1));
+        }
+    }
+
+    Component {
+        id: greenPassThrough
+        ShaderEffect {
+            fragmentShader:
+            "
+                uniform lowp sampler2D source;
+                varying highp vec2 qt_TexCoord0;
+                void main() {
+                    gl_FragColor = texture2D(source, qt_TexCoord0) * vec4(0, 1, 0, 1);
+                }
+            "
+        }
+    }
+
+    Row {
+        id: theRow
+        x: 10
+        y: 10
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ff0000"
+            layer.enabled: true
+        }
+
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ffffff"
+            layer.enabled: true
+            layer.effect: greenPassThrough
+        }
+
+        Rectangle {
+            id: blueInRow
+            width: 10
+            height: 10
+            color: "#0000ff"
+        }
+    }
+
+    Column {
+        id: theColumn
+        x: 10
+        y: 30
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ff0000"
+            layer.enabled: true
+        }
+
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ffffff"
+            layer.enabled: true
+            layer.effect: greenPassThrough
+        }
+
+        Rectangle {
+            id: blueInColumn
+            width: 10
+            height: 10
+            color: "#0000ff"
+        }
+    }
+
+    Flow {
+        id: theFlow
+        x: 30
+        y: 30
+        width: 20
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ff0000"
+            layer.enabled: true
+        }
+
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ffffff"
+            layer.enabled: true
+            layer.effect: greenPassThrough
+        }
+
+        Rectangle {
+            id: blueInFlow
+            width: 10
+            height: 10
+            color: "#0000ff"
+        }
+    }
+
+    Grid {
+        id: theGrid
+        x: 60
+        y: 10
+        columns: 2
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ff0000"
+            layer.enabled: true
+        }
+
+        Rectangle {
+            width: 10
+            height: 10
+            color: "#ffffff"
+            layer.enabled: true
+            layer.effect: greenPassThrough
+        }
+
+        Rectangle {
+            id: blueInGrid
+            width: 10
+            height: 10
+            color: "#0000ff"
+        }
+    }
+
+}


### PR DESCRIPTION
Task-number: QTBUG-31269
Change-Id: Ic3bb76ea5a5055df614f2eaacd3031445f118ca7
Reviewed-by: Jan Arve Sæther jan-arve.saether@digia.com
Reviewed-by: Robin Burchell <robin+qt@viroteck.net>

Conflicts:
    src/quick/items/qquickitem.cpp
