### PR TITLE
Memory leak in InternalClass::destroy()

### DIFF
--- a/src/qml/jsruntime/qv4internalclass.cpp
+++ b/src/qml/jsruntime/qv4internalclass.cpp
@@ -457,11 +457,11 @@ void InternalClass::destroy()
         if (next->m_frozen)
             destroyStack.append(next->m_frozen);
 
-        for (size_t i = 0; i < transitions.size(); ++i) {
+        for (size_t i = 0; i < next->transitions.size(); ++i) {
             destroyStack.append(next->transitions.at(i).lookup);
         }
 
-        next->transitions.clear();
+        next->transitions.~vector<Transition>();
     }
 }
 


### PR DESCRIPTION
==2035== 11,724 bytes in 977 blocks are definitely lost in loss record 2,740 of 2,749
==2035==    at 0x4838424: operator new(unsigned int) (vg_replace_malloc.c:292)
==2035==    by 0x4C237EF: void std::vector<QV4::InternalClassTransition, std::allocator<QV4::InternalClassTransition> >::_M_insert_aux<QV4::InternalClassTransition const&>(__gnu_cxx::__normal_iterator<QV4::InternalClassTransition*, std::vector<QV4::InternalClassTransition, std::allocator<QV4::InternalClassTransition> > >, QV4::InternalClassTransition const&) (new_allocator.h:92)
==2035==    by 0x4C238F3: std::vector<QV4::InternalClassTransition, std::allocator<QV4::InternalClassTransition> >::insert(__gnu_cxx::__normal_iterator<QV4::InternalClassTransition*, std::vector<QV4::InternalClassTransition, std::allocator<QV4::InternalClassTransition> > >, QV4::InternalClassTransition const&) (vector.tcc:128)
==2035==    by 0x4C227ED: QV4::InternalClass::lookupOrInsertTransition(QV4::InternalClassTransition const&) (qv4internalclass.cpp:170)
==2035==    by 0x4C2282D: QV4::InternalClass::addMemberImpl(QV4::String_, QV4::PropertyAttributes, unsigned int_) (qv4internalclass.cpp:321)
==2035==    by 0x4C230BF: QV4::InternalClass::addMember(QV4::Object_, QV4::String_, QV4::PropertyAttributes, unsigned int_) (qv4internalclass.cpp:294)
==2035==    by 0x4C45EDD: QV4::Object::insertMember(QV4::StringRef, QV4::Property const&, QV4::PropertyAttributes) (qv4object.cpp:237)
==2035==    by 0x4C46DF1: QV4::Object::internalPut(QV4::StringRef, QV4::ValueRef) (qv4object_p.h:171)
==2035==    by 0x4CFC7A3: QV4::QtObject::QtObject(QV4::ExecutionEngine_, QQmlEngine_) (qv4object_p.h:248)
==2035==    by 0x4CFD567: QV4::GlobalExtensions::init(QQmlEngine_, QV4::Object_) (qqmlbuiltinfunctions.cpp:1594)
==2035==    by 0x4CF3D5B: QV8Engine::initializeGlobal() (qv8engine.cpp:435)
==2035==    by 0x4CF404B: QV8Engine::initQmlGlobalObject() (qv8engine.cpp:526)
==2035==    by 0x4C8B40D: QQmlEnginePrivate::init() (qqmlengine.cpp:817)
==2035==    by 0x4C8B6FD: QQmlEngine::QQmlEngine(QObject_) (qqmlengine.cpp:882)
==2035==    by 0x4A0F133: QQuickViewPrivate::init(QQmlEngine_) (qquickview.cpp:86)
==2035==    by 0x4A0F39B: QQuickView::QQuickView(QWindow_) (qquickview.cpp:195)
==2035==    by 0x485EDFF: MDeclarativeCachePrivate::qQuickView() (mdeclarativecache.cpp:186)
==2035==    by 0x4853C13: SailfishAppPriv::view() (sailfishapp_priv_boosted.cpp:43)
==2035==    by 0x4852837: SailfishApp::createView() (sailfishapp.cpp:62)
