### PR TITLE
Mark clip node dirty regardless of how its geometry was changed.

### DIFF
--- a/src/quick/items/qquickclipnode.cpp
+++ b/src/quick/items/qquickclipnode.cpp
@@ -114,8 +114,8 @@ void QQuickDefaultClipNode::updateGeometry()
             }
         }
 
-        markDirty(DirtyGeometry);
     }
+    markDirty(DirtyGeometry);
     setClipRect(m_rect);
 }
 


### PR DESCRIPTION
Task-number: QTBUG-38473
Change-Id: If6f91f1a82b89de01d254af34128b9aefebaad2d
Reviewed-by: Mitch Curtis mitch.curtis@digia.com
