### PR TITLE
Fix width/height property assignment during animations.

### DIFF
--- a/src/quick/items/qquickitem.cpp
+++ b/src/quick/items/qquickitem.cpp
@@ -6155,7 +6155,7 @@ void QQuickItem::setSize(const QSizeF &size)
     d->heightValid = true;
     d->widthValid = true;
 
-    if (QSizeF(d->width, d->height) == size)
+    if (d->width == size.width() && d->height == size.height())
         return;
 
     qreal oldHeight = d->height;


### PR DESCRIPTION
During animations the behavior of

anchors.fill: parent

and

width: parent.width
height: parent.height

can be different resulting in subtle UI bugs where the final value of a
property is not applied because it is within epsilon of the previous
value. Fixed by directly comparing the width and height instead of
using operator==(QSize, QSize) which does a fuzzy comparison.

Change-Id: I4288b93db2b7baacd9f71ae1932ae743a428313a
