### PR TITLE
Restore depth buffer usage when last render node is removed

### DIFF
--- a/src/quick/scenegraph/coreapi/qsgbatchrenderer.cpp
+++ b/src/quick/scenegraph/coreapi/qsgbatchrenderer.cpp
@@ -1071,6 +1071,9 @@ void Renderer::nodeWasRemoved(Node *node)
         if (e) {
             e->removed = true;
             m_elementsToDelete.add(e);
+
+            if (m_renderNodeElements.isEmpty())
+                m_useDepthBuffer = context()->openglContext()->format().depthBufferSize() > 0;
         }
     }
 


### PR DESCRIPTION
Adding a QSGRenderNode to the scene permanently disabled opaque batches
by disabling depth buffer usage. Reset the depth buffer usage to the
default value once last QSGRenderNode has been removed from the scene.

Change-Id: I760afde83ae9eaaf1b5571c37fd0081eb23b1f20
