### PR TITLE
Initialize _startX and _startY fields of QQuickTouchPoint

### DIFF
--- a/src/quick/items/qquickmultipointtoucharea_p.h
+++ b/src/quick/items/qquickmultipointtoucharea_p.h
@@ -79,6 +79,7 @@ public:
           _qmlDefined(qmlDefined),
           _inUse(false),
           _pressed(false),
+          _startX(0.0), _startY(0.0),
           _previousX(0.0), _previousY(0.0),
           _sceneX(0.0), _sceneY(0.0)
     {}


### PR DESCRIPTION
```
==30449== Conditional jump or move depends on uninitialised value(s)
==30449==    at 0x5804C8E: QQuickTouchPoint::setStartX(float) (qquickmultipointtoucharea.cpp:167)
==30449==    by 0x5804FFE: QQuickMultiPointTouchArea::updateTouchPoint(QQuickTouchPoint*, QTouchEvent::TouchPoint const*) (qquickmultipointtoucharea.cpp:591)
==30449==    by 0x5805BE8: QQuickMultiPointTouchArea::addTouchPoint(QTouchEvent::TouchPoint const*) (qquickmultipointtoucharea.cpp:543)
==30449==    by 0x580627E: QQuickMultiPointTouchArea::updateTouchData(QEvent*) (qquickmultipointtoucharea.cpp:464)
==30449==    by 0x5806725: QQuickMultiPointTouchArea::touchEvent(QTouchEvent*) (qquickmultipointtoucharea.cpp:404)
==30449==    by 0x5717850: QQuickItem::event(QEvent*) (qquickitem.cpp:7026)
==30449==    by 0x50092D4: QCoreApplicationPrivate::notify_helper(QObject*, QEvent*) (qcoreapplication.cpp:1003)
==30449==    by 0x500935A: QCoreApplication::notify(QObject*, QEvent*) (qcoreapplication.cpp:948)
==30449==    by 0x49BEBD4: QGuiApplication::notify(QObject*, QEvent*) (qguiapplication.cpp:1354)
==30449==    by 0x5009044: QCoreApplication::notifyInternal(QObject*, QEvent*) (qcoreapplication.cpp:886)
==30449==    by 0x5729BEA: QQuickWindowPrivate::deliverMatchingPointsToItem(QQuickItem*, QTouchEvent*, QSet<int>*, QSet<int> const&, QList<QTouchEvent::TouchPoint> const&, QSet<QQuickItem*>*) (qcoreapplication.h:232)
==30449==    by 0x572A530: QQuickWindowPrivate::deliverTouchPoints(QQuickItem*, QTouchEvent*, QList<QTouchEvent::TouchPoint> const&, QSet<int>*, QHash<QQuickItem*, QList<QTouchEvent::TouchPoint> >*, QSet<QQuickItem*>*) (qquickwindow.cpp:1940)
...
```
