### PR TITLE
Ignore mouse events synthesized by the OS in Quick2

### DIFF
--- a/src/quick/items/qquickmultipointtoucharea.cpp
+++ b/src/quick/items/qquickmultipointtoucharea.cpp
@@ -43,6 +43,7 @@
 #include <QtQuick/qquickwindow.h>
 #include <private/qsgadaptationlayer_p.h>
 #include <private/qquickitem_p.h>
+#include <private/qguiapplication_p.h>
 #include <QEvent>
 #include <QMouseEvent>
 #include <math.h>
@@ -677,6 +678,10 @@ bool QQuickMultiPointTouchArea::sendMouseEvent(QMouseEvent *event)
         QMouseEvent mouseEvent(event->type(), localPos, event->windowPos(), event->screenPos(),
                                event->button(), event->buttons(), event->modifiers());
         mouseEvent.setAccepted(false);
+        QGuiApplicationPrivate::setMouseEventCapsAndVelocity(&mouseEvent,
+                                                             QGuiApplicationPrivate::mouseEventCaps(event),
+                                                             QGuiApplicationPrivate::mouseEventVelocity(event));
+        QGuiApplicationPrivate::setMouseEventSource(&mouseEvent, Qt::MouseEventSynthesizedByQt);
 
         switch (mouseEvent.type()) {
         case QEvent::MouseMove:

--- a/src/quick/items/qquickwindow.cpp
+++ b/src/quick/items/qquickwindow.cpp
@@ -501,6 +501,7 @@ static QMouseEvent *touchToMouseEvent(QEvent::Type type, const QTouchEvent::Touc
         transformedVelocity = transformMatrix.mapVector(p.velocity()).toVector2D();
     }
     QGuiApplicationPrivate::setMouseEventCapsAndVelocity(me, event->device()->capabilities(), transformedVelocity);
+    QGuiApplicationPrivate::setMouseEventSource(me, Qt::MouseEventSynthesizedByQt);
     return me;
 }
 
@@ -1386,6 +1387,7 @@ QMouseEvent *QQuickWindowPrivate::cloneMouseEvent(QMouseEvent *event, QPointF *t
                                       event->windowPos(), event->screenPos(),
                                       event->button(), event->buttons(), event->modifiers());
     QGuiApplicationPrivate::setMouseEventCapsAndVelocity(me, caps, velocity);
+    QGuiApplicationPrivate::setMouseEventSource(me, QGuiApplicationPrivate::mouseEventSource(event));
     me->setTimestamp(event->timestamp());
     return me;
 }
@@ -1462,6 +1464,12 @@ bool QQuickWindowPrivate::deliverMouseEvent(QMouseEvent *event)
 void QQuickWindow::mousePressEvent(QMouseEvent *event)
 {
     Q_D(QQuickWindow);
+
+    if (event->source() == Qt::MouseEventSynthesizedBySystem) {
+        event->accept();
+        return;
+    }
+
 #ifdef MOUSE_DEBUG
     qWarning() << "QQuickWindow::mousePressEvent()" << event->localPos() << event->button() << event->buttons();
 #endif
@@ -1473,6 +1481,12 @@ void QQuickWindow::mousePressEvent(QMouseEvent *event)
 void QQuickWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     Q_D(QQuickWindow);
+
+    if (event->source() == Qt::MouseEventSynthesizedBySystem) {
+        event->accept();
+        return;
+    }
+
 #ifdef MOUSE_DEBUG
     qWarning() << "QQuickWindow::mouseReleaseEvent()" << event->localPos() << event->button() << event->buttons();
 #endif
@@ -1491,6 +1505,12 @@ void QQuickWindow::mouseReleaseEvent(QMouseEvent *event)
 void QQuickWindow::mouseDoubleClickEvent(QMouseEvent *event)
 {
     Q_D(QQuickWindow);
+
+    if (event->source() == Qt::MouseEventSynthesizedBySystem) {
+        event->accept();
+        return;
+    }
+
 #ifdef MOUSE_DEBUG
     qWarning() << "QQuickWindow::mouseDoubleClickEvent()" << event->localPos() << event->button() << event->buttons();
 #endif
@@ -1526,6 +1546,12 @@ bool QQuickWindowPrivate::sendHoverEvent(QEvent::Type type, QQuickItem *item,
 void QQuickWindow::mouseMoveEvent(QMouseEvent *event)
 {
     Q_D(QQuickWindow);
+
+    if (event->source() == Qt::MouseEventSynthesizedBySystem) {
+        event->accept();
+        return;
+    }
+
 #ifdef MOUSE_DEBUG
     qWarning() << "QQuickWindow::mouseMoveEvent()" << event->localPos() << event->button() << event->buttons();
 #endif


### PR DESCRIPTION
Depends on https://github.com/mer-qt/qtbase/pull/40.

Make QQuickWindow ignore mouse events generated by the system from
touch events (e.g. on Windows). This will allow us to remove the
mousefromtouch parameter for the windows plugin and restore accepting
all mouse events in the platform plugin as the default behavior.

Change-Id: I82ff5fa97b02ebc69b61735e2366176e0a6a406c
Reviewed-by: Friedemann Kleint Friedemann.Kleint@digia.com
Reviewed-by: Shawn Rutledge shawn.rutledge@digia.com
