### PR TITLE
[qtdeclarative] Fix build by requiring qthelp-devel tools. Contributes to MER#1181

### DIFF
--- a/rpm/qtdeclarative.spec
+++ b/rpm/qtdeclarative.spec
@@ -13,6 +13,7 @@ BuildRequires:  qt5-qtsql-devel
 BuildRequires:  qt5-qttest-devel
 BuildRequires:  qt5-qtxmlpatterns-devel
 BuildRequires:  qt5-qmake
+BuildRequires:  qt5-qttools-qthelp-devel
 BuildRequires:  fdupes
 BuildRequires:  python
 BuildRequires:  gdb


### PR DESCRIPTION
`make docs` doesn't work without qhelpgenerator which comes from
qt5-qttools-qthelp-devel so add that as a dependency.

Contributes to MER#1181
