### PR TITLE
[qtdeclarative] Fix PathView gesture grabbing. Fixes JB#31608

### DIFF
--- a/src/quick/items/qquickpathview.cpp
+++ b/src/quick/items/qquickpathview.cpp
@@ -1584,6 +1584,7 @@ void QQuickPathViewPrivate::handleMousePressEvent(QMouseEvent *event)
         return;
 
     startPoint = pointNear(event->localPos(), &startPc);
+    startPos = event->localPos();
     if (idx == items.count()) {
         qreal distance = qAbs(event->localPos().x() - startPoint.x()) + qAbs(event->localPos().y() - startPoint.y());
         if (distance > dragMargin)
@@ -1606,8 +1607,6 @@ void QQuickPathView::mouseMoveEvent(QMouseEvent *event)
     Q_D(QQuickPathView);
     if (d->interactive) {
         d->handleMouseMoveEvent(event);
-        if (d->stealMouse)
-            setKeepMouseGrab(true);
         event->accept();
     } else {
         QQuickItem::mouseMoveEvent(event);
@@ -1624,9 +1623,17 @@ void QQuickPathViewPrivate::handleMouseMoveEvent(QMouseEvent *event)
     qreal newPc;
     QPointF pathPoint = pointNear(event->localPos(), &newPc);
     if (!stealMouse) {
-        QPointF delta = pathPoint - startPoint;
-        if (qAbs(delta.x()) > qApp->styleHints()->startDragDistance() || qAbs(delta.y()) > qApp->styleHints()->startDragDistance()) {
-            stealMouse = true;
+        QPointF posDelta = event->localPos() - startPos;
+        if (QQuickWindowPrivate::dragOverThreshold(posDelta.y(), Qt::YAxis, event) || QQuickWindowPrivate::dragOverThreshold(posDelta.x(), Qt::XAxis, event)) {
+            // The touch has exceeded the threshold. If the movement along the path is close to the drag threshold
+            // then we'll assume that this gesture targets the PathView. This ensures PathView gesture grabbing
+            // is in sync with other items.
+            QPointF pathDelta = pathPoint - startPoint;
+            if (qAbs(pathDelta.x()) > qApp->styleHints()->startDragDistance() * 0.8
+                    || qAbs(pathDelta.y()) > qApp->styleHints()->startDragDistance() * 0.8) {
+                stealMouse = true;
+                q->setKeepMouseGrab(true);
+            }
         }
     } else {
         moveReason = QQuickPathViewPrivate::Mouse;

--- a/src/quick/items/qquickpathview_p_p.h
+++ b/src/quick/items/qquickpathview_p_p.h
@@ -135,6 +135,7 @@ public:
     qreal currentItemOffset;
     qreal startPc;
     QPointF startPoint;
+    QPointF startPos;
     qreal offset;
     qreal offsetAdj;
     qreal mappedRange;


### PR DESCRIPTION
This has already been applied to Qt upstream some time ago:

```
commit c85bfba382ca1ddf0573c8f59e95b25f804b83ff
Author: Martin Jones <martin.jones@jollamobile.com>
Date:   Wed Jul 23 16:07:31 2014 +1000

Synchronize PathView gesture grabbing with other items.

PathView didn't attempt to grab the gesture at the same event as other
items. This prevented PathView from rightfully claiming the gesture
before lower items in the stack. Use the same threshold test for
PathView as used elsewhere.

Task-number: QTBUG-37859
```
